### PR TITLE
Getting a structured StackTrace from WebIDLException

### DIFF
--- a/Blazor.WebIDL.sln
+++ b/Blazor.WebIDL.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
+# 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KristofferStrube.Blazor.WebIDL", "src\KristofferStrube.Blazor.WebIDL\KristofferStrube.Blazor.WebIDL.csproj", "{A405F92C-4BB9-4E64-8662-BD7A0C83932B}"
@@ -8,6 +8,19 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KristofferStrube.Blazor.WebIDL.WasmExample", "samples\KristofferStrube.Blazor.WebIDL.WasmExample\KristofferStrube.Blazor.WebIDL.WasmExample.csproj", "{965C3E3B-E0C2-4A00-A072-D8F94CE3FAFC}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KristofferStrube.Blazor.WebIDL.ServerExample", "samples\KristofferStrube.Blazor.WebIDL.ServerExample\KristofferStrube.Blazor.WebIDL.ServerExample.csproj", "{764B6974-2E11-4ED5-8789-F17623613095}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KristofferStrube.Blazor.Tests.WebIDL", "KristofferStrube.Blazor.Tests.WebIDL\KristofferStrube.Blazor.Tests.WebIDL.csproj", "{A5716670-3B44-4838-A3B7-5269A8F9C87B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{43152D9A-9399-44F9-8F60-05EA0AE1B122}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{FEFE451B-4979-45EE-8165-40E853D1260E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{1AF89D83-468B-4A51-8E9D-709045A678EA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{084BCDA5-E2ED-4226-9F6C-5E908BC08243}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,8 +40,21 @@ Global
 		{764B6974-2E11-4ED5-8789-F17623613095}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{764B6974-2E11-4ED5-8789-F17623613095}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{764B6974-2E11-4ED5-8789-F17623613095}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5716670-3B44-4838-A3B7-5269A8F9C87B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5716670-3B44-4838-A3B7-5269A8F9C87B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5716670-3B44-4838-A3B7-5269A8F9C87B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5716670-3B44-4838-A3B7-5269A8F9C87B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{A405F92C-4BB9-4E64-8662-BD7A0C83932B} = {FEFE451B-4979-45EE-8165-40E853D1260E}
+		{965C3E3B-E0C2-4A00-A072-D8F94CE3FAFC} = {1AF89D83-468B-4A51-8E9D-709045A678EA}
+		{764B6974-2E11-4ED5-8789-F17623613095} = {1AF89D83-468B-4A51-8E9D-709045A678EA}
+		{A5716670-3B44-4838-A3B7-5269A8F9C87B} = {084BCDA5-E2ED-4226-9F6C-5E908BC08243}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B01568F6-6900-41F3-8993-175694634DEB}
 	EndGlobalSection
 EndGlobal

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,105 @@
+<Project>
+
+	<PropertyGroup>
+		<IsBenchmarkProject Condition="$(MSBuildProjectName.EndsWith('.Performance'))">true</IsBenchmarkProject>
+		<IsTestProject Condition="$(MSBuildProjectName.ToLower().Contains('.tests.'))">true</IsTestProject>
+		<IsTestAssetProject Condition="$(RepoRelativeProjectDir.Contains('testassets'))">true</IsTestAssetProject>
+		<IsSampleProject Condition="$(MSBuildProjectName.ToLower().Contains('example'))">true</IsSampleProject>
+		<IsPrimaryProject Condition=" ('$(IsBenchmarkProject)' != 'true' And '$(IsTestProject)' != 'true' And '$(IsTestAssetProject)' != 'true' And '$(IsSampleProject)' != 'true') ">true</IsPrimaryProject>
+
+		<IncludeSource>false</IncludeSource>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+
+		<LangVersion>12.0</LangVersion>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<Product>Blazor.WebWorkers</Product>
+		<PackageVersion>0.6.0</PackageVersion>
+		<PackageVersion>0.6.0</PackageVersion>
+
+		<Authors>KristofferStrube</Authors>
+		<Copyright>Copyright © 2024 Kristoffer Strube and contributors. All rights reserved.</Copyright>
+		<NeutralLanguage>en-US</NeutralLanguage>
+		<!-- The SPDX name for the source license. See https://spdx.org/licenses/. -->
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		
+		<!-- Suppress warnings about using SemVer 2.0. -->
+		<NoWarn>$(NoWarn);NU5048</NoWarn>
+
+		<NoWarn>$(NoWarn);CS8002;CS8632;NU5104</NoWarn>
+		
+		<!-- Suppress warnings about browser-only compatibility. -->
+		<NoWarn>$(NoWarn);CA1416</NoWarn>
+
+		<!-- Suppress warnings about missing doc comments (for now). -->
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
+
+		<!-- Contact email address for NuGet packages and Linux installers. -->
+		<MaintainerEmail>opensource@nimbleapps.cloud</MaintainerEmail>
+
+		<PackageIconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
+		<PackageProjectUrl>https://github.com/KristofferStrube/Blazor.WebWorkers</PackageProjectUrl>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<PackageTags>Blazor;Wasm;Wrapper;WebIDL;ValueReference;Iterable;AsynchronouslyIterable;Maplike;Setlike;TypedArray;JSException;Exception;Error;Handling;DomException;EvalError;RangeError;ReferenceError;TypeError;URIError;JSInterop</PackageTags>
+		<Serviceable>true</Serviceable>
+
+		<RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
+		<RepositoryUrl>https://github.com/KristofferStrube/Blazor.WebIDL.git</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+	</PropertyGroup>
+
+	<!-- Compilation options -->
+	<PropertyGroup>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+		<!-- Instructs the compiler to use SHA256 instead of SHA1 when adding file hashes to PDBs. -->
+		<ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
+
+		<!-- Fixes a common error in targets implementing a NoBuild mode. -->
+		<BuildProjectReferences Condition=" '$(NoBuild)' == 'true' ">false</BuildProjectReferences>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" $(IsPrimaryProject) == 'true' ">
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)</DocumentationFile>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageIcon>icon.png</PackageIcon>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<StandardTestTfms>net8.0</StandardTestTfms>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" $(IsSampleProject) == 'true' ">
+		<GenerateProgramFile>false</GenerateProgramFile>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" $(IsTestProject) == 'true' ">
+		<IsPackable>false</IsPackable>
+		<TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+	</PropertyGroup>
+
+	<ItemGroup Condition=" $(IsTestProject) != 'true' and $(IsSampleProject) != 'true' ">
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.*" PrivateAssets="All" />
+
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>$(AssemblyName.Replace("KristofferStrube.Blazor.WebIDL", "KristofferStrube.Blazor.Tests.WebIDL"))</_Parameter1>
+		</AssemblyAttribute>
+
+	</ItemGroup>
+
+	<ItemGroup Condition=" $(IsTestProject) == 'true' ">
+		<PackageReference Include="FluentAssertions" Version="6.*" PrivateAssets="All" />
+		<PackageReference Include="FluentAssertions.Analyzers" Version="0.*" PrivateAssets="All" />
+		<PackageReference Include="MSTest" Version="3.*" />
+	</ItemGroup>
+
+</Project>

--- a/KristofferStrube.Blazor.Tests.WebIDL/Exceptions/WebIDLExceptionTests.cs
+++ b/KristofferStrube.Blazor.Tests.WebIDL/Exceptions/WebIDLExceptionTests.cs
@@ -1,0 +1,43 @@
+﻿using FluentAssertions;
+using KristofferStrube.Blazor.WebIDL.Exceptions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace KristofferStrube.Blazor.Tests.WebIDL.Exceptions;
+
+[TestClass]
+public class WebIDLExceptionTests
+{
+
+    /// <summary>
+    /// Tests that the <see cref="WebIDLException"/> can be constructed and that <see cref="WebIDLException.GetStackFrames" />
+    /// correctly parses the stack.
+    /// </summary>
+    [TestMethod]
+    public void WebIDLException_CanGetStackFrames_DeepStack()
+    {
+        var stacktrace = @"causeErrors@http://localhost:5010/myfunctions.js:7:9 
+        window.onmessage@http://localhost:5010/:21:17
+        EventHandlerNonNull*@http://localhost:5010/:18:9";
+
+        WebIDLException exception = new("message", stacktrace);
+        exception.Should().NotBeNull();
+        exception.Message.Should().Be("message");
+        exception.StackTrace.Should().Be(stacktrace);
+        exception.GetStackFrames().Should().NotBeNullOrEmpty().And.HaveCount(3);
+    }
+
+    /// <summary>
+    /// Tests that the <see cref="WebIDLException"/> can be constructed and that <see cref="WebIDLException.GetStackFrames" />
+    /// returns an empty list when there is no stack.
+    /// </summary>
+    [TestMethod]
+    public void WebIDLException_CanGetStackFrames_NoStack()
+    {
+        WebIDLException exception = new("message");
+        exception.Should().NotBeNull();
+        exception.Message.Should().Be("message");
+        exception.StackTrace.Should().BeNull();
+        exception.GetStackFrames().Should().NotBeNull().And.BeEmpty();
+    }
+
+}

--- a/KristofferStrube.Blazor.Tests.WebIDL/KristofferStrube.Blazor.Tests.WebIDL.csproj
+++ b/KristofferStrube.Blazor.Tests.WebIDL/KristofferStrube.Blazor.Tests.WebIDL.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFrameworks>net8.0;net7.0</TargetFrameworks>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\src\KristofferStrube.Blazor.WebIDL\KristofferStrube.Blazor.WebIDL.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/samples/KristofferStrube.Blazor.WebIDL.ServerExample/KristofferStrube.Blazor.WebIDL.ServerExample.csproj
+++ b/samples/KristofferStrube.Blazor.WebIDL.ServerExample/KristofferStrube.Blazor.WebIDL.ServerExample.csproj
@@ -1,13 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net7.0</TargetFramework>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\KristofferStrube.Blazor.WebIDL\KristofferStrube.Blazor.WebIDL.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\KristofferStrube.Blazor.WebIDL\KristofferStrube.Blazor.WebIDL.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/samples/KristofferStrube.Blazor.WebIDL.WasmExample/KristofferStrube.Blazor.WebIDL.WasmExample.csproj
+++ b/samples/KristofferStrube.Blazor.WebIDL.WasmExample/KristofferStrube.Blazor.WebIDL.WasmExample.csproj
@@ -1,22 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+	
+	<PropertyGroup>
+		<TargetFramework>net7.0</TargetFramework>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.3" PrivateAssets="all" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.*" PrivateAssets="all" />
+		<PackageReference Include="System.Text.Json" Version="8.*" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\KristofferStrube.Blazor.WebIDL\KristofferStrube.Blazor.WebIDL.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\KristofferStrube.Blazor.WebIDL\KristofferStrube.Blazor.WebIDL.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Content Update="Pages\MapLike.razor">
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Update="Pages\MapLike.razor">
+			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+		</Content>
+	</ItemGroup>
+	
 </Project>

--- a/samples/KristofferStrube.Blazor.WebIDL.WasmExample/Pages/MapLike.razor
+++ b/samples/KristofferStrube.Blazor.WebIDL.WasmExample/Pages/MapLike.razor
@@ -24,9 +24,9 @@
     Map map = default!;
     ulong size;
     List<string> values = new();
-    string inputText = "";
-    double inputNumber = 0;
-    bool inputBoolean = false;
+    //string inputText = "";
+    //double inputNumber = 0;
+    //bool inputBoolean = false;
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/KristofferStrube.Blazor.WebIDL/Exceptions/WebIDLException.cs
+++ b/src/KristofferStrube.Blazor.WebIDL/Exceptions/WebIDLException.cs
@@ -1,25 +1,64 @@
-﻿namespace KristofferStrube.Blazor.WebIDL.Exceptions;
+﻿using System.Diagnostics;
+using System.Text.RegularExpressions;
+
+namespace KristofferStrube.Blazor.WebIDL.Exceptions;
 
 /// <summary>
 /// A common exception class for all exceptions from the <c>Blazor.WebIDL</c> library.
 /// </summary>
-public class WebIDLException : Exception
+public partial class WebIDLException : Exception
 {
-    private readonly string? jSStackTrace;
+
+    ///RWM: Source - https://github.com/MindscapeHQ/raygun4blazor/pull/25#discussion_r1694840772
+    [GeneratedRegex(@"(?<functionName>.+)@(?<fileName>.+):(?<lineNumber>\d+):(?<columnNumber>\d+)", RegexOptions.IgnoreCase)]
+    private static partial Regex StackFrameRegex();
+
+    private readonly string? jsStackTrace;
 
     /// <summary>
-    /// Returns the stack trace as a string. If no stack trace is available, null is returned. The stack is prepended with the JS stack trace if there is any.
+    /// Returns the stack trace as a string.
     /// </summary>
-    public override string? StackTrace => jSStackTrace is not null ? jSStackTrace + '\n' + base.StackTrace : base.StackTrace;
+    /// <remarks>
+    /// If no stack trace is available, null is returned. The stack is prepended with the JS stack trace if there is any.
+    /// </remarks>
+    public override string? StackTrace => 
+        // @robertmclaws: Doing it this way prevents unnecessary whitespace from being added to the trace, breaking tests.
+        string.IsNullOrWhiteSpace(jsStackTrace) && string.IsNullOrWhiteSpace(base.StackTrace) ?
+        null :
+        $"{jsStackTrace}{(!string.IsNullOrWhiteSpace(base.StackTrace) ? "\n" : null)}{base.StackTrace}";
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <returns>
+    /// A <see cref="List{StackFrame}" /> containing the <see cref="StackTrace"/> parsed as a series of <see cref="StackFrame">StackFrames</see>.
+    /// </returns>
+    public List<StackFrame?> GetStackFrames()
+    {
+        if (StackTrace is null) return [];
+
+        return StackTrace
+            .Split('\n')
+            .Where(frame => !string.IsNullOrWhiteSpace(frame))
+            .Select(frame =>
+            {
+                Match match = StackFrameRegex().Match(frame);
+                return !match.Success ?
+                    null :
+                    new StackFrame(match.Groups["fileName"].Value, int.Parse(match.Groups["lineNumber"].Value), int.Parse(match.Groups["columnNumber"].Value));
+            })
+            .Where(c => c is not null)
+            .ToList();
+    }
 
     /// <summary>
     /// Constructs a wrapper Exception for the given error.
     /// </summary>
     /// <param name="message">User agent-defined value that provides human readable details of the error.</param>
-    /// <param name="jSStackTrace">The stack trace from JavaScript if there is any.</param>
+    /// <param name="jsStackTrace">The stack trace from JavaScript if there is any.</param>
     /// <param name="innerException">Inner exception which is the cause of this exception.</param>
-    public WebIDLException(string message, string? jSStackTrace, Exception innerException) : base(message, innerException)
+    public WebIDLException(string message, string? jsStackTrace = default, Exception? innerException = null) : base(message, innerException)
     {
-        this.jSStackTrace = jSStackTrace;
+        this.jsStackTrace = jsStackTrace;
     }
 }

--- a/src/KristofferStrube.Blazor.WebIDL/KristofferStrube.Blazor.WebIDL.csproj
+++ b/src/KristofferStrube.Blazor.WebIDL/KristofferStrube.Blazor.WebIDL.csproj
@@ -1,38 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Title>Blazor WebIDL Standard wrapper</Title>
-    <Description>WebIDL Standard wrapper implementation for Blazor.</Description>
-    <PackageId>KristofferStrube.Blazor.WebIDL</PackageId>
-    <PackageTags>Blazor;Wasm;Wrapper;WebIDL;ValueReference;Iterable;AsynchronouslyIterable;Maplike;Setlike;TypedArray;JSException;Exception;Error;Handling;DomException;EvalError;RangeError;ReferenceError;TypeError;URIError;JSInterop</PackageTags>
-    <RepositoryUrl>https://github.com/KristofferStrube/Blazor.WebIDL</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageVersion>0.5.1</PackageVersion>
-    <Authors>Kristoffer Strube</Authors>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>icon.png</PackageIcon>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net8.0;net7.0</TargetFrameworks>
+		<DocumentationFile>$(DocumentationFile)\$(AssemblyName).xml</DocumentationFile>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\..\docs\icon.png">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-    <None Include="..\..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
+	<PropertyGroup>
+		<Title>Blazor WebIDL Standard wrapper</Title>
+		<Description>WebIDL Standard wrapper implementation for Blazor.</Description>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <SupportedPlatform Include="browser" />
-  </ItemGroup>
+	<ItemGroup>
+		<SupportedPlatform Include="browser" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.3" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)'=='net8.0'">
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.*" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'=='net7.0'">
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.*" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="..\..\docs\icon.png">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+		<None Include="..\..\README.md">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+	</ItemGroup>
+
+
 </Project>


### PR DESCRIPTION
- Enhancements to `WebIDLException` to efficiently parse the StackTrace.
- Unit tests to verify the `WebIDLException` behavior
- Framework-specific builds for .NET 8 and .NET 7 (to prevent manually having to re-target the deprecated `System.Text.Json` v 7.x in .NET 8 apps)
- Inclusion of `Directory.Build.props` to simplify project files